### PR TITLE
Added support for sendContext

### DIFF
--- a/src/MassTransit.OpenTracing/MassTransitPublishContextTextMapInjectAdapter.cs
+++ b/src/MassTransit.OpenTracing/MassTransitPublishContextTextMapInjectAdapter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using OpenTracing;
+using OpenTracing.Propagation;
+
+namespace MassTransit.OpenTracing
+{
+    public class MassTransitPublishContextTextMapInjectAdapter : ITextMap
+    {
+        private readonly PublishContext _context;
+        public MassTransitPublishContextTextMapInjectAdapter(PublishContext context)
+        {
+            _context = context;
+        }
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            throw new NotSupportedException(
+                $"{nameof(TextMapInjectAdapter)} should only be used with {nameof(ITracer)}.{nameof(ITracer.Inject)}");
+        }
+
+        public void Set(string key, string value)
+        {
+            _context.Headers.Set(key, value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/MassTransit.OpenTracing/MassTransitsSendContextTextMapInjectAdapter.cs
+++ b/src/MassTransit.OpenTracing/MassTransitsSendContextTextMapInjectAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using OpenTracing;
@@ -6,10 +6,10 @@ using OpenTracing.Propagation;
 
 namespace MassTransit.OpenTracing
 {
-    public class MassTransitTextMapInjectAdapter : ITextMap
+    public class MassTransitSendContextTextMapInjectAdapter : ITextMap
     {
-        private readonly PublishContext _context;
-        public MassTransitTextMapInjectAdapter(PublishContext context)
+        private readonly SendContext _context;
+        public MassTransitSendContextTextMapInjectAdapter(SendContext context)
         {
             _context = context;
         }

--- a/src/MassTransit.OpenTracing/OpenTracingMiddlewareConfiguratorExtensions.cs
+++ b/src/MassTransit.OpenTracing/OpenTracingMiddlewareConfiguratorExtensions.cs
@@ -5,6 +5,7 @@ namespace MassTransit.OpenTracing
         public static void PropagateOpenTracingContext(this IBusFactoryConfigurator value)
         {
             value.ConfigurePublish(configurator => configurator.AddPipeSpecification(new OpenTracingPipeSpecification()));
+            value.ConfigureSend(configurator => configurator.AddPipeSpecification(new OpenTracingPipeSpecification()));
             value.AddPipeSpecification(new OpenTracingPipeSpecification());
         }
     }

--- a/src/MassTransit.OpenTracing/OpenTracingPipeSpecification.cs
+++ b/src/MassTransit.OpenTracing/OpenTracingPipeSpecification.cs
@@ -1,12 +1,14 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using GreenPipes;
 
 namespace MassTransit.OpenTracing
 {
-    public class OpenTracingPipeSpecification : IPipeSpecification<ConsumeContext>, IPipeSpecification<PublishContext>
+    public class OpenTracingPipeSpecification : IPipeSpecification<ConsumeContext>, IPipeSpecification<PublishContext>, IPipeSpecification<SendContext>
     {
-        public IEnumerable<ValidationResult> Validate()
+       
+
+       public IEnumerable<ValidationResult> Validate()
         {
             return Enumerable.Empty<ValidationResult>();
         }
@@ -20,5 +22,10 @@ namespace MassTransit.OpenTracing
         {
             builder.AddFilter(new OpenTracingPublishFilter());
         }
-    }
+
+        public void Apply(IPipeBuilder<SendContext> builder)
+        {
+            builder.AddFilter(new OpenTracingSendFilter());
+      }
+   }
 }

--- a/src/MassTransit.OpenTracing/OpenTracingSendFilter.cs
+++ b/src/MassTransit.OpenTracing/OpenTracingSendFilter.cs
@@ -5,14 +5,14 @@ using OpenTracing.Util;
 
 namespace MassTransit.OpenTracing
 {
-    public class OpenTracingPublishFilter : IFilter<PublishContext>
+    public class OpenTracingSendFilter : IFilter<SendContext>
     {
         public void Probe(ProbeContext context)
         { }
 
-        public async Task Send(PublishContext context, IPipe<PublishContext> next)
+        public async Task Send(SendContext context, IPipe<SendContext> next)
         {
-            var operationName = $"Publishing Message: {context.DestinationAddress.GetExchangeName()}";
+            var operationName = $"Sending Message: {context.DestinationAddress.GetExchangeName()}";
 
             var spanBuilder = GlobalTracer.Instance.BuildSpan(operationName)
                .AsChildOf(GlobalTracer.Instance.ActiveSpan.Context)
@@ -26,10 +26,11 @@ namespace MassTransit.OpenTracing
                 GlobalTracer.Instance.Inject(
                    GlobalTracer.Instance.ActiveSpan.Context,
                    BuiltinFormats.TextMap,
-                   new MassTransitPublishContextTextMapInjectAdapter(context));
+                   new MassTransitSendContextTextMapInjectAdapter(context));
 
                 await next.Send(context);
             }
         }
+
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change:

* Support for MassTransit `SendContext`

This is more  a start for a discussion, I have fork your lib and put it in one of my project.

I was something similar to [sending via interface](https://masstransit-project.com/MassTransit/usage/producing-messages.html#sending-via-interfaces)

```c#
public interface SubmitOrder
{
    string OrderId { get; }
    DateTime OrderDate { get; }
    decimal OrderAmount { get; }
}

public async Task SendOrder(ISendEndpoint endpoint)
{
    await endpoint.Send<SubmitOrder>(new
    {
        OrderId = "27",
        OrderDate = DateTime.UtcNow,
        OrderAmount = 123.45m
    });
}
```

and noticed that the `uber-trace-id` was missing in the message context:

```json
"headers": {
    "uber-trace-id": ""
  },
```

I did a quick modification to your code to accommodate this, as you can see there's some duplication as I went and copy paste most of your code (really handy btw).

## Type of change

- [x] New feature

# How Has This Been Tested?

I have tested this in a different project. no unit testing

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules